### PR TITLE
Highlight yaml in frontmatter

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,10 @@
 			{
 				"language": "cook",
 				"scopeName": "source.cook",
-				"path": "./syntaxes/cook.tmLanguage.json"
+				"path": "./syntaxes/cook.tmLanguage.json",
+				"embeddedLanguages": {
+					"meta.embedded.block.frontmatter": "yaml"
+				}
 			}
 		]
 	},

--- a/syntaxes/cook.tmLanguage.json
+++ b/syntaxes/cook.tmLanguage.json
@@ -4,6 +4,9 @@
   "scopeName": "source.cook",
   "patterns": [
     {
+			"include": "#frontMatter"
+		},
+    {
       "include": "#comments"
     },
     {
@@ -514,6 +517,36 @@
           "contentName": "comment.line.double-dash.cook"
         }
       ]
-    }
+    },
+    "frontMatter": {
+			"begin": "\\A(?=(-{3,}))",
+			"end": "^ {,3}\\1-*[ \\t]*$|^[ \\t]*\\.{3}$",
+			"applyEndPatternLast": 1,
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.end.frontmatter"
+				}
+			},
+			"patterns": [
+				{
+					"begin": "\\A(-{3,})(.*)$",
+					"while": "^(?! {,3}\\1-*[ \\t]*$|[ \\t]*\\.{3}$)",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.definition.begin.frontmatter"
+						},
+						"2": {
+							"name": "comment.frontmatter"
+						}
+					},
+					"contentName": "meta.embedded.block.frontmatter",
+					"patterns": [
+						{
+							"include": "source.yaml"
+						}
+					]
+				}
+			]
+		}
   }
 }


### PR DESCRIPTION
Hi, I've added basic highlighting for frontmatter (using https://github.com/microsoft/vscode/blob/main/extensions/markdown-basics/syntaxes/markdown.tmLanguage.json as a reference).

I'm not familiar with vscode extension publishing process, so I didn't touch metadata stuff. 